### PR TITLE
Include Database memory utilization check for Elasticache

### DIFF
--- a/modules/elasticache-review/README.md
+++ b/modules/elasticache-review/README.md
@@ -43,7 +43,7 @@ No modules.
 | <a name="input_email_address_list"></a> [email\_address\_list](#input\_email\_address\_list) | List of email addreses to send under-utilised DB list through SNS | `list(string)` | `[]` | no |
 | <a name="input_slack_webhook_ssm"></a> [slack\_webhook\_ssm](#input\_slack\_webhook\_ssm) | AWS Parameter store name for slack endpoint to send under-utilised DB list in using AWS lambda | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
+| <a name="input_cpu_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
 
 ## Outputs
 
@@ -94,13 +94,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cpu_utilisation_threshold"></a> [cpu\_utilisation\_threshold](#input\_cpu\_utilisation\_threshold) | This is the CPU utilization threshold in percentage below which an Elasticache instance is considered under-utilised. | `number` | `0` | no |
 | <a name="input_days_interval"></a> [days\_interval](#input\_days\_interval) | The Cloudwatch period / interval to review metrics for the Elasticache instances. | `number` | `7` | no |
 | <a name="input_email_address_list"></a> [email\_address\_list](#input\_email\_address\_list) | List of email addreses to send under-utilised Elasticache list through SNS | `list(string)` | `[]` | no |
 | <a name="input_exempt_instances_classes"></a> [exempt\_instances\_classes](#input\_exempt\_instances\_classes) | List of Elasticache instance classes that are expemted from monitoring. | `list(string)` | `[]` | no |
+| <a name="input_memory_utilisation_threshold"></a> [memory\_utilisation\_threshold](#input\_memory\_utilisation\_threshold) | This is the memory utilization threshold in percentage below which an Elasticache instance is considered under-utilised. | `number` | `25` | no |
 | <a name="input_review_frequency"></a> [review\_frequency](#input\_review\_frequency) | This is the cron frenquency to be used by the lambda script. It states how often the lambda script is to be run to review the Elasticache instances. It is provided in AWS cron expression in UTC+0 - https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions. Default value is to run every Monday at 12 PM UTC. | `string` | `"0 12 ? * 2 *"` | no |
 | <a name="input_slack_webhook_ssm"></a> [slack\_webhook\_ssm](#input\_slack\_webhook\_ssm) | AWS Parameter store name for slack endpoint to send under-utilised Elasticache list in using AWS lambda | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an Elasticache instance is considered under-utilised. | `number` | `25` | no |
 
 ## Outputs
 

--- a/modules/elasticache-review/main.tf
+++ b/modules/elasticache-review/main.tf
@@ -17,10 +17,11 @@ resource "aws_lambda_function" "elasticache_review" {
 
   environment {
     variables = {
-      SNS_ARN               = aws_sns_topic.elasticache_review.arn
-      DAYS_INTERVAL         = var.days_interval
-      EC_CPU_UTIL_THRESHOLD = var.utilisation_threshold
-      SLACK_WEBHOOK_SSM     = var.slack_webhook_ssm
+      SNS_ARN                  = aws_sns_topic.elasticache_review.arn
+      DAYS_INTERVAL            = var.days_interval
+      EC_CPU_UTIL_THRESHOLD    = var.cpu_utilisation_threshold
+      EC_DB_MEM_UTIL_THRESHOLD = var.memory_utilisation_threshold
+      SLACK_WEBHOOK_SSM        = var.slack_webhook_ssm
     }
   }
   depends_on = [

--- a/modules/elasticache-review/variables.tf
+++ b/modules/elasticache-review/variables.tf
@@ -27,10 +27,16 @@ variable "exempt_instances_classes" {
   default     = []
 }
 
-variable "utilisation_threshold" {
-  description = "This is the CPU Utilization threshold in percentage below which an Elasticache instance is considered under-utilised."
+variable "cpu_utilisation_threshold" {
+  description = "This is the CPU utilization threshold in percentage below which an Elasticache instance is considered under-utilised."
   type        = number
   default     = 0
+}
+
+variable "memory_utilisation_threshold" {
+  description = "This is the memory utilization threshold in percentage below which an Elasticache instance is considered under-utilised."
+  type        = number
+  default     = 25
 }
 
 variable "tags" {

--- a/modules/rds-review/README.md
+++ b/modules/rds-review/README.md
@@ -43,7 +43,7 @@ No modules.
 | <a name="input_email_address_list"></a> [email\_address\_list](#input\_email\_address\_list) | List of email addreses to send under-utilised DB list through SNS | `list(string)` | `[]` | no |
 | <a name="input_slack_webhook_ssm"></a> [slack\_webhook\_ssm](#input\_slack\_webhook\_ssm) | AWS Parameter store name for slack endpoint to send under-utilised DB list in using AWS lambda | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
+| <a name="input_cpu_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
 
 ## Outputs
 
@@ -94,13 +94,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cpu_utilisation_threshold"></a> [cpu\_utilisation\_threshold](#input\_cpu\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
 | <a name="input_days_interval"></a> [days\_interval](#input\_days\_interval) | The Cloudwatch period / interval to review metrics for the RDS instances. | `number` | `7` | no |
 | <a name="input_email_address_list"></a> [email\_address\_list](#input\_email\_address\_list) | List of email addreses to send under-utilised DB list through SNS | `list(string)` | `[]` | no |
 | <a name="input_exempt_db_classes"></a> [exempt\_db\_classes](#input\_exempt\_db\_classes) | List of DB instance classes that are expemted from monitoring. | `list(string)` | `[]` | no |
 | <a name="input_review_frequency"></a> [review\_frequency](#input\_review\_frequency) | This is the cron frenquency to be used by the lambda script. It states how often the lambda script is to be run to review the RDS instances. It is provided in AWS cron expression in UTC+0 - https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions. Default value is to run every Monday at 12 PM UTC. | `string` | `"0 12 ? * 2 *"` | no |
 | <a name="input_slack_webhook_ssm"></a> [slack\_webhook\_ssm](#input\_slack\_webhook\_ssm) | AWS Parameter store name for slack endpoint to send under-utilised DB list in using AWS lambda | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
-| <a name="input_utilisation_threshold"></a> [utilisation\_threshold](#input\_utilisation\_threshold) | This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised. | `number` | `25` | no |
 
 ## Outputs
 

--- a/modules/rds-review/lambda-script/lambda_function.py
+++ b/modules/rds-review/lambda-script/lambda_function.py
@@ -14,7 +14,7 @@ def lambda_handler(event, context):
 
     sns_arn = os.environ['SNS_ARN']
     day_interval = os.environ['DAYS_INTERVAL']
-    db_utilisation_threshold = os.environ["DB_UTIL_THRESHOLD"]
+    db_cpu_utilisation_threshold = os.environ["DB_CPU_UTIL_THRESHOLD"]
     slack_webhook_ssm = os.environ["SLACK_WEBHOOK_SSM"]
     aws_region = os.environ["AWS_REGION"]
 
@@ -61,14 +61,14 @@ def lambda_handler(event, context):
 
         cpu_utilization_percentage = cloudwatch_response["Datapoints"][0]["ExtendedStatistics"]["p99"]
 
-        if int(cpu_utilization_percentage) <= int(db_utilisation_threshold):
-            db_return_list.append(f"{db_identifier} : {cpu_utilization_percentage:.2f}%")
+        if int(cpu_utilization_percentage) <= int(db_cpu_utilisation_threshold):
+            db_return_list.append(f"{db_identifier} => {cpu_utilization_percentage:.2f}%")
     
     logger.info(f"{db_return_list.count} DB instances are currently under-utilised.")
 
     if db_return_list:
 
-        db_return_list.insert(0, f"The list of under-utilised RDS instances in `{aws_region}` region for the past `{day_interval}` days (_instances below `{db_utilisation_threshold}%` CPUUtilization_)")
+        db_return_list.insert(0, f"The list of under-utilised RDS instances in `{aws_region}` region for the past `{day_interval}` days (_instances below `{db_cpu_utilisation_threshold}%` CPUUtilization_)")
 
         if sns_arn:
             logger.info(f"Sending under-utilised DB list through SNS.")

--- a/modules/rds-review/main.tf
+++ b/modules/rds-review/main.tf
@@ -17,10 +17,10 @@ resource "aws_lambda_function" "rds_review" {
 
   environment {
     variables = {
-      SNS_ARN           = aws_sns_topic.rds_review.arn
-      DAYS_INTERVAL     = var.days_interval
-      DB_UTIL_THRESHOLD = var.utilisation_threshold
-      SLACK_WEBHOOK_SSM = var.slack_webhook_ssm
+      SNS_ARN               = aws_sns_topic.rds_review.arn
+      DAYS_INTERVAL         = var.days_interval
+      DB_CPU_UTIL_THRESHOLD = var.cpu_utilisation_threshold
+      SLACK_WEBHOOK_SSM     = var.slack_webhook_ssm
     }
   }
   depends_on = [

--- a/modules/rds-review/variables.tf
+++ b/modules/rds-review/variables.tf
@@ -27,7 +27,7 @@ variable "exempt_db_classes" {
   default     = []
 }
 
-variable "utilisation_threshold" {
+variable "cpu_utilisation_threshold" {
   description = "This is the CPU Utilization threshold in percentage below which an RDS instance is considered under-utilised."
   type        = number
   default     = 25


### PR DESCRIPTION
Elasticache review depends on not just CPU metrics but Memory as well. 

This update will enable checks for CPU as well and Memory utilization before concluding that an Elasticache instance is under-utilzed.

Ref: https://aws.amazon.com/blogs/database/monitoring-best-practices-with-amazon-elasticache-for-redis-using-amazon-cloudwatch/